### PR TITLE
Add compatibility with thud and zeus

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_meta-noto = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-noto = "6"
 
 LAYERDEPENDS_meta-noto = "core"
-LAYERSERIES_COMPAT_meta-noto = "warrior"
+LAYERSERIES_COMPAT_meta-noto = "thud warrior zeus"


### PR DESCRIPTION
I only tested the `noto-sans-cjk-regular` recipe with these yocto releases which worked fine.