### PR TITLE
Add compatibility with dunfell

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_meta-noto = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-noto = "6"
 
 LAYERDEPENDS_meta-noto = "core"
-LAYERSERIES_COMPAT_meta-noto = "thud warrior zeus"
+LAYERSERIES_COMPAT_meta-noto = "thud warrior zeus dunfell"


### PR DESCRIPTION
As last time, I only tested the noto-sans-cjk-regular recipe with this yocto release which worked fine.