### PR TITLE
layer.conf: set LAYERSERIES_COMPAT to honister (Yocto 3.4)

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -11,6 +11,5 @@ BBFILE_PRIORITY_meta-noto = "6"
 
 LAYERDEPENDS_meta-noto = "core"
 # meta-noto now has branches for each release. Switch your meta-noto branches
-# to the released branches for production builds. This LAYERSERIES_COMPAT list
-# may be pruned in the future
-LAYERSERIES_COMPAT_meta-noto = "thud warrior zeus dunfell gatesgarth hardknott master"
+# to the released branches for production builds. 
+LAYERSERIES_COMPAT_meta-noto = "honister"


### PR DESCRIPTION
The Yocto meta layers switched the  LAYER_SERIES_COMPAT to the next Yocto 3.4 release name, honister on 2021-07-30.  A new 'honister' branch also needs  be created from off this commit