### PR TITLE
Add dunfell as compatible

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_meta-noto = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-noto = "6"
 
 LAYERDEPENDS_meta-noto = "core"
-LAYERSERIES_COMPAT_meta-noto = "honister"
+LAYERSERIES_COMPAT_meta-noto = "dunfell honister"


### PR DESCRIPTION
Since the override syntax is at least backported to dunfell, it is still
compatible. So add dunfell back as compatible version.

Hint: Bitbake must be updated if this does fail.

Signed-off-by: Jeroen Hofstee <jhofstee@victronenergy.com>