### PR TITLE
layer.conf: update LAYERSERIES_COMPAT for mickledore

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_meta-noto = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-noto = "6"
 
 LAYERDEPENDS_meta-noto = "core"
-LAYERSERIES_COMPAT_meta-noto = "langdale"
+LAYERSERIES_COMPAT_meta-noto = "mickledore"


### PR DESCRIPTION
* oe-core switched to mickedore in: https://git.openembedded.org/openembedded-core/commit/?id=57239d66b933c4313cf331d35d13ec2d0661c38f

Signed-off-by: Geoff Parker <geoffrey.parker@arthrex.com>