### PR TITLE
Add noto-sans-mono-hinted fonts to layer

### DIFF
--- a/recipes-graphics/noto-fonts/noto-sans-mono-hinted.bb
+++ b/recipes-graphics/noto-fonts/noto-sans-mono-hinted.bb
@@ -1,0 +1,5 @@
+inherit noto-fonts
+inherit noto-styles
+
+SRC_URI = "${NOTO_SRC_URI_PREFIX}/NotoSansMono-hinted.zip"
+SRC_URI[sha256sum] = "08bc1d07e546ce79d8b8abd6812c86d77fba5d1f4b54529390e8a57d65827b76"


### PR DESCRIPTION
We use some of the noto-sans-mono fonts, so I would like to add them to this layer.

Signed-off-by: Pascal Zimmermann <pzimmermann@dh-electronics.com>