### PR TITLE
Yocto 5.1 (styhead): S = ${WORKDIR} no longer supported

### DIFF
--- a/classes/noto-fonts.bbclass
+++ b/classes/noto-fonts.bbclass
@@ -19,7 +19,8 @@ NOTO_SRC_URI_PREFIX = "https://noto-website-2.storage.googleapis.com/pkgs"
 NOTOFONTS_SRC_URI_PREFIX = "https://github.com/notofonts"
 
 
-S = "${WORKDIR}"
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
 
 # we don't need a compiler nor a c library for these fonts
 INHIBIT_DEFAULT_DEPS = "1"


### PR DESCRIPTION
Fix errors during parse due to S = ${WORKDIR}
https://docs.yoctoproject.org/next/migration-guides/migration-5.1.html#workdir-changes :

    S = ${WORKDIR} no longer supported

    If a recipe has S set to be WORKDIR, this is no longer supported,
    and an error will be issued. The recipe should be changed to:

    S = "${WORKDIR}/sources"
    UNPACKDIR = "${S}"

    Any WORKDIR references where files from SRC_URI are referenced
    should be changed to S. These are commonly in do_compile,
    do_compile, do_install and LIC_FILES_CHKSUM.