### PR TITLE
Add Arabic, Devanagari, Lao, and Hebrew fonts (master)

### DIFF
--- a/classes/noto-fonts-base.bbclass
+++ b/classes/noto-fonts-base.bbclass
@@ -1,0 +1,29 @@
+# Stuff common to all google noto fonts
+
+SUMMARY ??= "Google noto font package ${PN}"
+SECTION = "fonts"
+
+HOMEPAGE ??= "https://www.google.com/get/noto/"
+
+# all google noto fonts are OFL-1.1 licensed
+LICENSE = "OFL-1.1"
+LIC_FILES_CHKSUM = "file://LICENSE_OFL.txt;md5=55719faa0112708e946b820b24b14097"
+
+inherit allarch fontcache
+
+NOTO_SRC_URI_PREFIX = "https://noto-website-2.storage.googleapis.com/pkgs"
+
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+
+# we don't need a compiler nor a c library for these fonts
+INHIBIT_DEFAULT_DEPS = "1"
+
+FONT_INSTALL_DIR = "${datadir}/fonts/opentype/noto"
+
+do_install() {
+    install -d ${D}${FONT_INSTALL_DIR}
+}
+
+# Default file inclusion for fonts that does not have many styles
+FILES:${PN} = "${FONT_INSTALL_DIR}/*"

--- a/classes/noto-fonts-hinted.bbclass
+++ b/classes/noto-fonts-hinted.bbclass
@@ -1,0 +1,18 @@
+inherit noto-fonts-base
+
+# Goole now has separate repo for different fonts
+#   zip release:  ${NOTOFONTS_SRC_URI_PREFIX}/<font language>/releases/tag/<font name>-v${PV}/<font name>-v${PV}.zip
+#                 https://gitbub.com/notofonts/thai/releases/tag/NotoSansThai-v2.002/NotoSansThai-v2.002.zip
+NOTOFONTS_SRC_URI_PREFIX = "https://github.com/notofonts"
+
+# Assumed each font will set STYLE_LANG (eg Thai, Lao) and STYLE_EDGE (eg Sans, Serif)
+STYLE_ROOT="${@d.getVar('STYLE_LANG').lower()}"
+STYLE_NAME="Noto${STYLE_EDGE}${STYLE_LANG}"
+SRC_URI = "${NOTOFONTS_SRC_URI_PREFIX}/${STYLE_ROOT}/releases/download/${STYLE_NAME}-v${PV}/${STYLE_NAME}-v${PV}.zip"
+
+LIC_FILES_CHKSUM = "file://OFL.txt;md5=f319a2b8bcf8e25835957d7835f177b0"
+
+do_install:append() {
+    # Search hinted only, ignore variable fonts by using only otf/ttf directories
+    find ./ -wholename '*/hinted/[ot]t[cf]/*.[ot]t[cf]' -exec install -m 0644 {} ${D}${FONT_INSTALL_DIR} \;
+}

--- a/classes/noto-fonts.bbclass
+++ b/classes/noto-fonts.bbclass
@@ -1,36 +1,5 @@
-# Stuff common to all google noto fonts
+inherit noto-fonts-base
 
-SUMMARY ??= "Google noto font package ${PN}"
-SECTION = "fonts"
-
-HOMEPAGE ??= "https://www.google.com/get/noto/"
-
-# all google noto fonts are OFL-1.1 licensed
-LICENSE = "OFL-1.1"
-LIC_FILES_CHKSUM = "file://LICENSE_OFL.txt;md5=55719faa0112708e946b820b24b14097"
-
-inherit allarch fontcache
-
-# legacy prefix
-NOTO_SRC_URI_PREFIX = "https://noto-website-2.storage.googleapis.com/pkgs"
-# Goole now has separate repo for different fonts
-#   zip release:  ${NOTOFONTS_SRC_URI_PREFIX}/<font language>/releases/tag/<font name>-v${PV}/<font name>-v${PV}.zip
-#                 https://gitbub.com/notofonts/thai/releases/tag/NotoSansThai-v2.002/NotoSansThai-v2.002.zip
-NOTOFONTS_SRC_URI_PREFIX = "https://github.com/notofonts"
-
-
-S = "${WORKDIR}/sources"
-UNPACKDIR = "${S}"
-
-# we don't need a compiler nor a c library for these fonts
-INHIBIT_DEFAULT_DEPS = "1"
-
-FONT_INSTALL_DIR = "${datadir}/fonts/opentype/noto"
-
-do_install() {
-    install -d ${D}${FONT_INSTALL_DIR}
+do_install:append() {
     find ./ -name '*.[ot]t[cf]' -exec install -m 0644 {} ${D}${FONT_INSTALL_DIR} \;
 }
-
-# Default file inclusion for fonts that does not have many styles
-FILES:${PN} = "${FONT_INSTALL_DIR}/*"

--- a/recipes-graphics/noto-arabic/noto-kufi-arabic_2.109.bb
+++ b/recipes-graphics/noto-arabic/noto-kufi-arabic_2.109.bb
@@ -1,0 +1,8 @@
+inherit noto-fonts-hinted
+inherit noto-styles
+
+STYLE_EDGE="Kufi"
+STYLE_LANG="Arabic"
+
+LIC_FILES_CHKSUM = "file://OFL.txt;md5=f319a2b8bcf8e25835957d7835f177b0"
+SRC_URI[sha256sum] = "1b6880e4b8df09c3b9e246d6084bfd94bf32a0ffff60cf2dcffd3622d0e2d79f"

--- a/recipes-graphics/noto-arabic/noto-naskh-arabic_2.019.bb
+++ b/recipes-graphics/noto-arabic/noto-naskh-arabic_2.019.bb
@@ -1,0 +1,8 @@
+inherit noto-fonts-hinted
+inherit noto-styles
+
+STYLE_EDGE="Naskh"
+STYLE_LANG="Arabic"
+
+LIC_FILES_CHKSUM = "file://OFL.txt;md5=f319a2b8bcf8e25835957d7835f177b0"
+SRC_URI[sha256sum] = "7a509e10c9c8d21f384a26807ef2f5fbbecec46fdb8626c5441bed6d894edb81"

--- a/recipes-graphics/noto-arabic/noto-sans-arabic_2.012.bb
+++ b/recipes-graphics/noto-arabic/noto-sans-arabic_2.012.bb
@@ -1,0 +1,8 @@
+inherit noto-fonts-hinted
+inherit noto-styles
+
+STYLE_EDGE="Sans"
+STYLE_LANG="Arabic"
+
+LIC_FILES_CHKSUM = "file://OFL.txt;md5=f319a2b8bcf8e25835957d7835f177b0"
+SRC_URI[sha256sum] = "65bceb5106ca17e8e0b4660bacec4d362afd56e0251e71fedf83f76dfe9f4abe"

--- a/recipes-graphics/noto-devanagari/noto-sans-devanagari_2.006.bb
+++ b/recipes-graphics/noto-devanagari/noto-sans-devanagari_2.006.bb
@@ -1,0 +1,8 @@
+inherit noto-fonts-hinted
+inherit noto-styles
+
+STYLE_EDGE="Sans"
+STYLE_LANG="Devanagari"
+
+LIC_FILES_CHKSUM = "file://OFL.txt;md5=e13edde515de034b8074223fadcff8a9"
+SRC_URI[sha256sum] = "4c582c103f0a42836338df07148b23a0aa080cce8393ddc4364af87eb22ebd85"

--- a/recipes-graphics/noto-devanagari/noto-serif-devanagari_2.006.bb
+++ b/recipes-graphics/noto-devanagari/noto-serif-devanagari_2.006.bb
@@ -1,0 +1,8 @@
+inherit noto-fonts-hinted
+inherit noto-styles
+
+STYLE_EDGE="Serif"
+STYLE_LANG="Devanagari"
+
+LIC_FILES_CHKSUM = "file://OFL.txt;md5=e13edde515de034b8074223fadcff8a9"
+SRC_URI[sha256sum] = "b823456dfaf6ef8b438eeb906da42effe01927add1e3416ecc86c99c5f1cf098"

--- a/recipes-graphics/noto-hebrew/noto-sans-hebrew_3.001.bb
+++ b/recipes-graphics/noto-hebrew/noto-sans-hebrew_3.001.bb
@@ -1,0 +1,8 @@
+inherit noto-fonts-hinted
+inherit noto-styles
+
+STYLE_EDGE="Sans"
+STYLE_LANG="Hebrew"
+
+LIC_FILES_CHKSUM = "file://OFL.txt;md5=7882143d530dbe277055ce240ee92558"
+SRC_URI[sha256sum] = "df0a71814b4e63644cf40fcc4529111b61266b7a2dafbe95068b29a7520cc3cb"

--- a/recipes-graphics/noto-hebrew/noto-serif-hebrew_2.004.bb
+++ b/recipes-graphics/noto-hebrew/noto-serif-hebrew_2.004.bb
@@ -1,0 +1,8 @@
+inherit noto-fonts-hinted
+inherit noto-styles
+
+STYLE_EDGE="Serif"
+STYLE_LANG="Hebrew"
+
+LIC_FILES_CHKSUM = "file://OFL.txt;md5=7882143d530dbe277055ce240ee92558"
+SRC_URI[sha256sum] = "99523f4f21051495f18cbd5169ed0d1e9b395eefe770fece1844a4a7a00c46da"

--- a/recipes-graphics/noto-lao/noto-sans-lao-looped_1.002.bb
+++ b/recipes-graphics/noto-lao/noto-sans-lao-looped_1.002.bb
@@ -1,0 +1,8 @@
+inherit noto-fonts-hinted
+inherit noto-styles
+
+STYLE_EDGE="Sans"
+STYLE_LANG="Lao"
+STYLE_NAME="Noto${STYLE_EDGE}${STYLE_LANG}Looped"
+
+SRC_URI[sha256sum] = "8006a78e1a208838d605bcc3264f5e7e54eb9d5ccf330cfed42d17b257391a50"

--- a/recipes-graphics/noto-lao/noto-sans-lao_2.003.bb
+++ b/recipes-graphics/noto-lao/noto-sans-lao_2.003.bb
@@ -1,0 +1,8 @@
+inherit noto-fonts-hinted
+inherit noto-styles
+
+STYLE_EDGE="Sans"
+STYLE_LANG="Lao"
+
+LIC_FILES_CHKSUM = "file://OFL.txt;md5=667099facaed0b90e3145542745c30ef"
+SRC_URI[sha256sum] = "5a87c31b1a40ef8147c1e84437e5f0ceba2d4dbbfc0b56a65821ad29870da8c0"

--- a/recipes-graphics/noto-lao/noto-serif-lao_2.003.bb
+++ b/recipes-graphics/noto-lao/noto-serif-lao_2.003.bb
@@ -1,0 +1,8 @@
+inherit noto-fonts-hinted
+inherit noto-styles
+
+STYLE_EDGE="Serif"
+STYLE_LANG="Lao"
+
+LIC_FILES_CHKSUM = "file://OFL.txt;md5=667099facaed0b90e3145542745c30ef"
+SRC_URI[sha256sum] = "e96a303d3347790b0ef3db274971a989a736ce766ec9ea1bea0e1458568a80b2"

--- a/recipes-graphics/noto-thai/noto-sans-thai-looped_1.001.bb
+++ b/recipes-graphics/noto-thai/noto-sans-thai-looped_1.001.bb
@@ -1,8 +1,10 @@
 
-inherit noto-fonts
+inherit noto-fonts-hinted
 inherit noto-styles
 
-LIC_FILES_CHKSUM = "file://OFL.txt;md5=d7c94b25f07127276c3e513f9f9d2b33"
-SRC_URI = "${NOTOFONTS_SRC_URI_PREFIX}/thai/releases/download/NotoSansThaiLooped-v${PV}/NotoSansThaiLooped-v${PV}.zip"
+STYLE_EDGE="Sans"
+STYLE_LANG="Thai"
+STYLE_NAME="Noto${STYLE_EDGE}${STYLE_LANG}Looped"
 
+LIC_FILES_CHKSUM = "file://OFL.txt;md5=d7c94b25f07127276c3e513f9f9d2b33"
 SRC_URI[sha256sum] = "5155c03ce182eaf5e03ffc050a8f38b35eede76b9cc4c91a89fc22834251980d"

--- a/recipes-graphics/noto-thai/noto-sans-thai_2.002.bb
+++ b/recipes-graphics/noto-thai/noto-sans-thai_2.002.bb
@@ -1,14 +1,9 @@
 
-inherit noto-fonts
+inherit noto-fonts-hinted
 inherit noto-styles
 
+STYLE_EDGE="Sans"
+STYLE_LANG="Thai"
+
 LIC_FILES_CHKSUM = "file://OFL.txt;md5=d7c94b25f07127276c3e513f9f9d2b33"
-SRC_URI = "${NOTOFONTS_SRC_URI_PREFIX}/thai/releases/download/NotoSansThai-v${PV}/NotoSansThai-v${PV}.zip"
-
 SRC_URI[sha256sum] = "af889cc673fc714060ce5e4e088fbad32aa4c0571a19958efeaff128a22da485"
-
-do_install:append() {
-  # get rid of NotoSansThai[wdth,wght].ttf and NotoSansThai[wght].ttf with literal brackets,
-  # since they don't fit packaging scheme and we don't need them (just use the single-style files) 
-  rm ${D}/usr/share/fonts/opentype/noto/NotoSansThai\[*
-}

--- a/recipes-graphics/noto-thai/noto-serif-thai_2.002.bb
+++ b/recipes-graphics/noto-thai/noto-serif-thai_2.002.bb
@@ -1,14 +1,9 @@
 
-inherit noto-fonts
+inherit noto-fonts-hinted
 inherit noto-styles
 
+STYLE_EDGE="Serif"
+STYLE_LANG="Thai"
+
 LIC_FILES_CHKSUM = "file://OFL.txt;md5=d7c94b25f07127276c3e513f9f9d2b33"
-SRC_URI = "${NOTOFONTS_SRC_URI_PREFIX}/thai/releases/download/NotoSerifThai-v${PV}/NotoSerifThai-v${PV}.zip"
-
 SRC_URI[sha256sum] = "89e3c04bfc54d9a5dd0aec660bf974ad46df38385df7d9397c083482d515049a"
-
-do_install:append() {
-  # get rid of NotoSerifThai[wdth,wght].ttf and NotoSerifThai[wght].ttf with literal brackets,
-  # since they don't fit packaging scheme and we don't need them (just use the single-style files) 
-  rm ${D}/usr/share/fonts/opentype/noto/NotoSerifThai\[*
-}


### PR DESCRIPTION
* Use the new noto font's url.
* Changed font code to choose the hinted fonts instead of using find blindly. As this resulted in unhinted fonts overwriting others due to alphabetical search order.
* Changed code to not copy variable fonts at all, so that recipies don't need to delete it in an install append step.
* Changed Thai fonts to use the hinted fonts.
* Reworked the bbclasses to remove duplicate code.