### PR TITLE
layer.conf: LAYERSERIES_COMPAT_meta-noto add wrynose (Yocto 6.0 LTS)

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_meta-noto = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-noto = "6"
 
 LAYERDEPENDS_meta-noto = "core"
-LAYERSERIES_COMPAT_meta-noto = "walnascar whinlatter"
+LAYERSERIES_COMPAT_meta-noto = "walnascar whinlatter wrynose"


### PR DESCRIPTION
Add wrynose to master branch LAYERSERIES_COMPAT_meta-noto variable in layer.conf.

Note: https://github.com/ssfivy/meta-noto/issues/39 still needs to be fixed to fix fetching