### PR TITLE
noto-serif-display-hinted: Add missing do_install:append() delete filter

### DIFF
--- a/recipes-graphics/noto-fonts/noto-serif-display-hinted_2.009.bb
+++ b/recipes-graphics/noto-fonts/noto-serif-display-hinted_2.009.bb
@@ -8,6 +8,9 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/OFL-1.1;md5=fac3a519e5e9eb96316
 SRC_URI = "${NOTO_LGC_SRC_URI_PREFIX}/NotoSerifDisplay-v${PV}/NotoSerifDisplay-v${PV}.zip"
 SRC_URI[sha256sum] = "ef1df6b20037f5a7e5af30023359253e37ee199b2bf97143a01c88c5097af467"
 
-# This release contains only variable fonts; ship them all in the base package
-FILES:${PN} += "${FONT_INSTALL_DIR}/*"
+do_install:append() {
+    # The new release bundles variable fonts (bracket notation); remove them
+    # as noto-styles splits packages by static weight suffixes only
+    find ${D}${FONT_INSTALL_DIR} -name '*\[*\]*' -delete
+}
 

--- a/recipes-graphics/noto-fonts/noto-serif-hinted_2.015.bb
+++ b/recipes-graphics/noto-fonts/noto-serif-hinted_2.015.bb
@@ -6,6 +6,8 @@ SRC_URI = "${NOTO_LGC_SRC_URI_PREFIX}/NotoSerif-v${PV}/NotoSerif-v${PV}.zip"
 SRC_URI[sha256sum] = "0e9a43c8a4b94ac76f55069ed1d7385bbcaf6b99527a94deb5619e032b7e76c1"
 
 do_install:append() {
+    # The new release bundles variable fonts (bracket notation); remove them
+    # as noto-styles splits packages by static weight suffixes only
     find ${D}${FONT_INSTALL_DIR} -name '*\[*\]*' -delete
 }
 


### PR DESCRIPTION
@Fix QA error:  Files/directories were installed but not shipped in any package

The noto-serif-display-hinted recipe should be similar to noto-sans-display-hinted recipe, which includes a do_install:append() to remove variable fonts from being installed.

fixes https://github.com/ssfivy/meta-noto/issues/44

cc: @CrazyGecko @bith3ad @opoznia